### PR TITLE
Mlockall.setup

### DIFF
--- a/elasticsearch/etc/default_config
+++ b/elasticsearch/etc/default_config
@@ -17,7 +17,7 @@ ES_HEAP_SIZE={{ pillar.elasticsearch.heap_size }}
 MAX_OPEN_FILES=65535
 
 # Maximum amount of locked memory
-#MAX_LOCKED_MEMORY=
+MAX_LOCKED_MEMORY=unlimited
 
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 MAX_MAP_COUNT=262144

--- a/elasticsearch/etc/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/etc/elasticsearch/elasticsearch.yml
@@ -58,6 +58,11 @@ path.data: /mnt/elasticsearch/data
 path.work: /mnt/elasticsearch/work
 path.logs: /mnt/elasticsearch/logs
 
+# Disable the JVM from being swapped out
+bootstrap.mlockall: true
+
+
+
 {% if shield %}
 # Shield settings
 shield.http.ssl: true

--- a/elasticsearch/install.sls
+++ b/elasticsearch/install.sls
@@ -96,3 +96,12 @@ elasticsearch_default_config:
     - mode: 644
     - require:
       - pkg: elasticsearch
+
+/etc/security/limits.conf:
+  file.append:
+    - text:
+      - elasticsearch - memlock unlimited
+      - root - memlock unlimited
+
+/bin/sed 's/#LimitMEMLOCK=infinity/LimitMEMLOCK=infinity/' /usr/lib/systemd/system/elasticsearch.service
+  cmd.run

--- a/elasticsearch/install.sls
+++ b/elasticsearch/install.sls
@@ -103,5 +103,5 @@ elasticsearch_default_config:
       - elasticsearch - memlock unlimited
       - root - memlock unlimited
 
-/bin/sed 's/#LimitMEMLOCK=infinity/LimitMEMLOCK=infinity/' /usr/lib/systemd/system/elasticsearch.service
+/bin/sed 's/#LimitMEMLOCK=infinity/LimitMEMLOCK=infinity/' /usr/lib/systemd/system/elasticsearch.service:
   cmd.run


### PR DESCRIPTION
Updated to let Elastic lock the JVM memory to prevent swapping this is best practice, elimenates errors from the log and can be seen at http://localhost:9200/_nodes/process?pretty under "mlockall"
